### PR TITLE
Commit forgotten .cabal file update

### DIFF
--- a/github-app-token.cabal
+++ b/github-app-token.cabal
@@ -12,6 +12,8 @@ category:       HTTP
 homepage:       https://github.com/freckle/github-app-token#readme
 bug-reports:    https://github.com/freckle/github-app-token/issues
 maintainer:     Freckle Education
+license:        MIT
+license-file:   LICENSE
 build-type:     Simple
 extra-doc-files:
     README.md


### PR DESCRIPTION
Adding the LICENSE file told hpack to do this, and I didn't commit it.
