### PR TITLE
Implement fewer wake-ups when waiting to refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## [_Unreleased_](https://github.com/freckle/github-app-token/compare/v0.0.1.2...main)
 
-## [v0.0.1.0](https://github.com/freckle/github-app-token/compare/v0.0.1.0...v0.0.1.1)
+## [v0.0.1.2](https://github.com/freckle/github-app-token/compare/v0.0.1.1...v0.0.1.2)
 
 - Implement refresh wake-ups more efficiently
 
-## [v0.0.1.0](https://github.com/freckle/github-app-token/compare/v0.0.0.1...v0.0.1.1)
+## [v0.0.1.1](https://github.com/freckle/github-app-token/compare/v0.0.0.1...v0.0.1.1)
 
 - Add `GitHub.App.Token.Refresh`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [_Unreleased_](https://github.com/freckle/github-app-token/compare/v0.0.1.1...main)
+## [_Unreleased_](https://github.com/freckle/github-app-token/compare/v0.0.1.2...main)
 
-## [v0.0.1.0](https://github.com/freckle/github-app-token/tree/v0.0.1.1)
+## [v0.0.1.0](https://github.com/freckle/github-app-token/compare/v0.0.1.0...v0.0.1.1)
+
+- Implement refresh wake-ups more efficiently
+
+## [v0.0.1.0](https://github.com/freckle/github-app-token/compare/v0.0.0.1...v0.0.1.1)
 
 - Add `GitHub.App.Token.Refresh`
 

--- a/github-app-token.cabal
+++ b/github-app-token.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           github-app-token
-version:        0.0.1.1
+version:        0.0.1.2
 synopsis:       Generate an installation access token for a GitHub App
 description:    Please see README.md
 category:       HTTP

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: github-app-token
-version: 0.0.1.1
+version: 0.0.1.2
 maintainer: Freckle Education
 category: HTTP
 github: freckle/github-app-token


### PR DESCRIPTION
Rather than wake up every 0.5 seconds and check if the thing has
expired, just sleep for 95% until we expect it to expire, then wake up
and refresh it.
