### PR TITLE
Update README

### DIFF
--- a/github-app-token.cabal
+++ b/github-app-token.cabal
@@ -86,15 +86,15 @@ test-suite readme
       TypeFamilies
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe -pgmL markdown-unlit
   build-depends:
-      base <5
+      aeson
+    , base <5
     , bytestring
     , directory
     , dotenv
     , github-app-token
+    , hspec
     , http-conduit
     , http-types
-    , lens
-    , lens-aeson
     , markdown-unlit
     , text
   default-language: GHC2021

--- a/package.yaml
+++ b/package.yaml
@@ -78,13 +78,13 @@ tests:
     main: README.lhs
     ghc-options: -pgmL markdown-unlit
     dependencies:
+      - aeson
       - bytestring
       - directory
       - dotenv
       - github-app-token
       - http-conduit
       - http-types
-      - lens
-      - lens-aeson
+      - hspec
       - markdown-unlit
       - text


### PR DESCRIPTION
- Separate `getAppToken` as an example specifically for generation, and
  show a more realistic "get repo" function that uses it
- Update (hidden) `main` to use `Hspec`
- Add example with `Refresh` usage
