### PR TITLE
generateInstallationTokenScoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/github-app-token/compare/v0.0.1.2...main)
+## [_Unreleased_](https://github.com/freckle/github-app-token/compare/v0.0.2.0...main)
+
+## [v0.0.2.0](https://github.com/freckle/github-app-token/compare/v0.0.1.2...v0.0.2.0)
+
+- Add `generateInstallationTokenScoped` and related types
 
 ## [v0.0.1.2](https://github.com/freckle/github-app-token/compare/v0.0.1.1...v0.0.1.2)
 

--- a/README.lhs
+++ b/README.lhs
@@ -66,6 +66,29 @@ getRepo name = do
   pure $ getResponseBody resp
 ```
 
+## Scoping
+
+By default, a token is created with repositories access and permissions as
+defined in the installation configuration. Either of these can be changed by
+using `generateInstallationTokenScoped`:
+
+```haskell
+getScopedAppToken :: IO AccessToken
+getScopedAppToken = do
+  appId <- AppId . read <$> getEnv "GITHUB_APP_ID"
+  privateKey <- PrivateKey . BS8.pack <$> getEnv "GITHUB_PRIVATE_KEY"
+  installationId <- InstallationId . read <$> getEnv "GITHUB_INSTALLATION_ID"
+
+  let
+    creds = AppCredentials {appId, privateKey}
+    create = mempty
+      { repositories = ["freckle/github-app-token"]
+      , permissions = contents Read
+      }
+
+  generateInstallationTokenScoped create creds installationId
+```
+
 ## Refreshing
 
 Installation tokens are good for one hour, after which point using them will

--- a/github-app-token.cabal
+++ b/github-app-token.cabal
@@ -29,6 +29,7 @@ library
       GitHub.App.Token.AppCredentials
       GitHub.App.Token.Generate
       GitHub.App.Token.JWT
+      GitHub.App.Token.Permissions
       GitHub.App.Token.Prelude
       GitHub.App.Token.Refresh
   other-modules:
@@ -57,7 +58,9 @@ library
     , http-conduit
     , http-types
     , jwt
+    , monoidal-containers
     , path
+    , semigroups
     , text
     , time
     , unliftio
@@ -105,6 +108,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      GitHub.App.Token.PermissionsSpec
       GitHub.App.Token.RefreshSpec
       Paths_github_app_token
   hs-source-dirs:
@@ -125,7 +129,8 @@ test-suite spec
       TypeFamilies
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe -threaded -rtsopts "-with-rtsopts=-N"
   build-depends:
-      base <5
+      aeson
+    , base <5
     , github-app-token
     , hspec
     , time

--- a/github-app-token.cabal
+++ b/github-app-token.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           github-app-token
-version:        0.0.1.2
+version:        0.0.2.0
 synopsis:       Generate an installation access token for a GitHub App
 description:    Please see README.md
 category:       HTTP

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: github-app-token
-version: 0.0.1.2
+version: 0.0.2.0
 maintainer: Freckle Education
 category: HTTP
 github: freckle/github-app-token

--- a/package.yaml
+++ b/package.yaml
@@ -58,9 +58,11 @@ library:
     - bytestring
     - http-conduit
     - jwt
+    - semigroups
     - text
     - time
     - http-types
+    - monoidal-containers
     - path
     - unliftio
 
@@ -70,6 +72,7 @@ tests:
     source-dirs: tests
     ghc-options: -threaded -rtsopts "-with-rtsopts=-N"
     dependencies:
+      - aeson
       - github-app-token
       - time
       - unliftio

--- a/src/GitHub/App/Token.hs
+++ b/src/GitHub/App/Token.hs
@@ -5,7 +5,13 @@ module GitHub.App.Token
   , PrivateKey (..)
   , InstallationId (..)
   , AccessToken (..)
+
+    -- * Scoped
+  , CreateAccessToken (..)
+  , module GitHub.App.Token.Permissions
+  , generateInstallationTokenScoped
   ) where
 
 import GitHub.App.Token.AppCredentials
 import GitHub.App.Token.Generate
+import GitHub.App.Token.Permissions

--- a/src/GitHub/App/Token/Permissions.hs
+++ b/src/GitHub/App/Token/Permissions.hs
@@ -82,6 +82,7 @@ import GitHub.App.Token.Prelude hiding (Read)
 import Data.Aeson (ToJSON (..))
 import Data.Map.Monoidal.Strict (MonoidalMap)
 import Data.Map.Monoidal.Strict qualified as MonoidalMap
+import Data.Semigroup (Max (..))
 
 {-# ANN module ("HLint: ignore Use camelCase" :: String) #-}
 
@@ -95,14 +96,8 @@ data Permission
   = PermissionRead
   | PermissionWrite
   | PermissionAdmin
-  deriving stock (Eq, Show)
-
-instance Semigroup Permission where
-  _ <> PermissionAdmin = PermissionAdmin
-  PermissionAdmin <> _ = PermissionAdmin
-  _ <> PermissionWrite = PermissionWrite
-  PermissionWrite <> _ = PermissionWrite
-  PermissionRead <> PermissionRead = PermissionRead
+  deriving stock (Eq, Ord, Show)
+  deriving (Semigroup) via (Max Permission)
 
 instance ToJSON Permission where
   toJSON =

--- a/src/GitHub/App/Token/Permissions.hs
+++ b/src/GitHub/App/Token/Permissions.hs
@@ -1,0 +1,306 @@
+-- | Type-safe implementation for requesting 'AccessToken' permissions
+--
+-- <https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app>
+--
+-- Usage:
+--
+-- 1. Use a constructor function for a specific permission, each of which only
+--    accepts appropriate values (e.g. you can't ask for @admin@ on a permission
+--    that only allows @read@ or @write@).
+-- 2. Combine these using 'Permissions' 'Semigroup' instance.
+--
+-- For example:
+--
+-- @
+-- let permissions = 'actions' 'Read' <> 'checks' 'Write'
+--
+-- 'generateInstallationTokenScoped' AllRepositories permissions creds installationId
+-- @
+--
+-- Supplying the same permission more than once will take the higher:
+--
+-- @
+-- 'checks' 'Read' <> 'checks' 'Write' == 'checks' 'Write'
+-- @
+module GitHub.App.Token.Permissions
+  ( Permissions
+  , Read (..)
+  , Write (..)
+  , Admin (..)
+  , actions
+  , administration
+  , checks
+  , codespaces
+  , contents
+  , dependabot_secrets
+  , deployments
+  , environments
+  , issues
+  , metadata
+  , packages
+  , pages
+  , pull_requests
+  , repository_custom_properties
+  , repository_hooks
+  , repository_projects
+  , secret_scanning_alerts
+  , secrets
+  , security_events
+  , single_file
+  , statuses
+  , vulnerability_alerts
+  , workflows
+  , members
+  , organization_administration
+  , organization_custom_roles
+  , organization_custom_org_roles
+  , organization_custom_properties
+  , organization_copilot_seat_management
+  , organization_announcement_banners
+  , organization_events
+  , organization_hooks
+  , organization_personal_access_tokens
+  , organization_personal_access_token_requests
+  , organization_plan
+  , organization_projects
+  , organization_packages
+  , organization_secrets
+  , organization_self_hosted_runners
+  , organization_user_blocking
+  , team_discussions
+  , email_addresses
+  , followers
+  , git_ssh_keys
+  , gpg_keys
+  , interaction_limits
+  , profile
+  , starring
+  ) where
+
+import GitHub.App.Token.Prelude hiding (Read)
+
+import Data.Aeson (ToJSON (..))
+import Data.Map.Monoidal.Strict (MonoidalMap)
+import Data.Map.Monoidal.Strict qualified as MonoidalMap
+
+{-# ANN module ("HLint: ignore Use camelCase" :: String) #-}
+
+newtype Permissions = Permissions
+  { _unwrap :: MonoidalMap Text Permission
+  }
+  deriving stock (Eq)
+  deriving newtype (Semigroup, Monoid, ToJSON)
+
+data Permission
+  = PermissionRead
+  | PermissionWrite
+  | PermissionAdmin
+  deriving stock (Eq)
+
+instance Semigroup Permission where
+  _ <> PermissionAdmin = PermissionAdmin
+  PermissionAdmin <> _ = PermissionAdmin
+  _ <> PermissionWrite = PermissionWrite
+  PermissionWrite <> _ = PermissionWrite
+  PermissionRead <> PermissionRead = PermissionRead
+
+instance ToJSON Permission where
+  toJSON =
+    toJSON @Text . \case
+      PermissionRead -> "read"
+      PermissionWrite -> "write"
+      PermissionAdmin -> "admin"
+
+class AsReadWrite a where
+  toReadWritePermission :: a -> Permission
+
+class AsReadWriteAdmin a where
+  toReadWriteAdminPermission :: a -> Permission
+
+data Read = Read
+
+instance AsReadWrite Read where
+  toReadWritePermission _ = PermissionRead
+
+instance AsReadWriteAdmin Read where
+  toReadWriteAdminPermission _ = PermissionRead
+
+data Write = Write
+
+instance AsReadWrite Write where
+  toReadWritePermission _ = PermissionWrite
+
+instance AsReadWriteAdmin Write where
+  toReadWriteAdminPermission _ = PermissionWrite
+
+data Admin = Admin
+
+instance AsReadWriteAdmin Admin where
+  toReadWriteAdminPermission _ = PermissionAdmin
+
+actions :: AsReadWrite a => a -> Permissions
+actions = mkReadWrite "actions"
+
+administration :: AsReadWrite a => a -> Permissions
+administration = mkReadWrite "administration"
+
+checks :: AsReadWrite a => a -> Permissions
+checks = mkReadWrite "checks"
+
+codespaces :: AsReadWrite a => a -> Permissions
+codespaces = mkReadWrite "codespaces"
+
+contents :: AsReadWrite a => a -> Permissions
+contents = mkReadWrite "contents"
+
+dependabot_secrets :: AsReadWrite a => a -> Permissions
+dependabot_secrets = mkReadWrite "dependabot_secrets"
+
+deployments :: AsReadWrite a => a -> Permissions
+deployments = mkReadWrite "deployments"
+
+environments :: AsReadWrite a => a -> Permissions
+environments = mkReadWrite "environments"
+
+issues :: AsReadWrite a => a -> Permissions
+issues = mkReadWrite "issues"
+
+metadata :: AsReadWrite a => a -> Permissions
+metadata = mkReadWrite "metadata"
+
+packages :: AsReadWrite a => a -> Permissions
+packages = mkReadWrite "packages"
+
+pages :: AsReadWrite a => a -> Permissions
+pages = mkReadWrite "pages"
+
+pull_requests :: AsReadWrite a => a -> Permissions
+pull_requests = mkReadWrite "pull_requests"
+
+repository_custom_properties :: AsReadWrite a => a -> Permissions
+repository_custom_properties = mkReadWrite "repository_custom_properties"
+
+repository_hooks :: AsReadWrite a => a -> Permissions
+repository_hooks = mkReadWrite "repository_hooks"
+
+repository_projects :: AsReadWriteAdmin a => a -> Permissions
+repository_projects = mkReadWriteAdmin "repository_projects"
+
+secret_scanning_alerts :: AsReadWrite p => p -> Permissions
+secret_scanning_alerts = mkReadWrite "secret_scanning_alerts"
+
+secrets :: AsReadWrite p => p -> Permissions
+secrets = mkReadWrite "secrets"
+
+security_events :: AsReadWrite p => p -> Permissions
+security_events = mkReadWrite "security_events"
+
+single_file :: AsReadWrite p => p -> Permissions
+single_file = mkReadWrite "single_file"
+
+statuses :: AsReadWrite p => p -> Permissions
+statuses = mkReadWrite "statuses"
+
+vulnerability_alerts :: AsReadWrite p => p -> Permissions
+vulnerability_alerts = mkReadWrite "vulnerability_alerts"
+
+-- | Only supported permission is 'Write'
+workflows :: Permissions
+workflows = mkWrite "workflows"
+
+members :: AsReadWrite p => p -> Permissions
+members = mkReadWrite "members"
+
+organization_administration :: AsReadWrite p => p -> Permissions
+organization_administration = mkReadWrite "organization_administration"
+
+organization_custom_roles :: AsReadWrite p => p -> Permissions
+organization_custom_roles = mkReadWrite "organization_custom_roles"
+
+organization_custom_org_roles :: AsReadWrite p => p -> Permissions
+organization_custom_org_roles = mkReadWrite "organization_custom_org_roles"
+
+organization_custom_properties :: AsReadWriteAdmin p => p -> Permissions
+organization_custom_properties = mkReadWriteAdmin "organization_custom_properties"
+
+-- | Only supported permission is 'Write'
+organization_copilot_seat_management :: Permissions
+organization_copilot_seat_management = mkWrite "organization_copilot_seat_management"
+
+organization_announcement_banners :: AsReadWrite p => p -> Permissions
+organization_announcement_banners = mkReadWrite "organization_announcement_banners"
+
+-- | Only supported permission is 'Read'
+organization_events :: Permissions
+organization_events = mkRead "organization_events"
+
+organization_hooks :: AsReadWrite p => p -> Permissions
+organization_hooks = mkReadWrite "organization_hooks"
+
+organization_personal_access_tokens :: AsReadWrite p => p -> Permissions
+organization_personal_access_tokens = mkReadWrite "organization_personal_access_tokens"
+
+organization_personal_access_token_requests :: AsReadWrite p => p -> Permissions
+organization_personal_access_token_requests = mkReadWrite "organization_personal_access_token_requests"
+
+-- | Only supported permission is 'Read'
+organization_plan :: Permissions
+organization_plan = mkRead "organization_plan"
+
+organization_projects :: AsReadWriteAdmin p => p -> Permissions
+organization_projects = mkReadWriteAdmin "organization_projects"
+
+organization_packages :: AsReadWrite p => p -> Permissions
+organization_packages = mkReadWrite "organization_packages"
+
+organization_secrets :: AsReadWrite p => p -> Permissions
+organization_secrets = mkReadWrite "organization_secrets"
+
+organization_self_hosted_runners :: AsReadWrite p => p -> Permissions
+organization_self_hosted_runners = mkReadWrite "organization_self_hosted_runners"
+
+organization_user_blocking :: AsReadWrite p => p -> Permissions
+organization_user_blocking = mkReadWrite "organization_user_blocking"
+
+team_discussions :: AsReadWrite p => p -> Permissions
+team_discussions = mkReadWrite "team_discussions"
+
+email_addresses :: AsReadWrite p => p -> Permissions
+email_addresses = mkReadWrite "email_addresses"
+
+followers :: AsReadWrite p => p -> Permissions
+followers = mkReadWrite "followers"
+
+git_ssh_keys :: AsReadWrite p => p -> Permissions
+git_ssh_keys = mkReadWrite "git_ssh_keys"
+
+gpg_keys :: AsReadWrite p => p -> Permissions
+gpg_keys = mkReadWrite "gpg_keys"
+
+interaction_limits :: AsReadWrite p => p -> Permissions
+interaction_limits = mkReadWrite "interaction_limits"
+
+-- | Only supported permission is 'Write'
+profile :: Permissions
+profile = mkWrite "profile"
+
+starring :: AsReadWrite p => p -> Permissions
+starring = mkReadWrite "starring"
+
+mkRead :: Text -> Permissions
+mkRead name = Permissions $ MonoidalMap.singleton name PermissionRead
+
+mkWrite :: Text -> Permissions
+mkWrite name = Permissions $ MonoidalMap.singleton name PermissionWrite
+
+mkReadWrite :: AsReadWrite p => Text -> p -> Permissions
+mkReadWrite name =
+  Permissions
+    . MonoidalMap.singleton name
+    . toReadWritePermission
+
+mkReadWriteAdmin :: AsReadWriteAdmin p => Text -> p -> Permissions
+mkReadWriteAdmin name =
+  Permissions
+    . MonoidalMap.singleton name
+    . toReadWriteAdminPermission

--- a/src/GitHub/App/Token/Permissions.hs
+++ b/src/GitHub/App/Token/Permissions.hs
@@ -14,7 +14,7 @@
 -- @
 -- let permissions = 'actions' 'Read' <> 'checks' 'Write'
 --
--- 'generateInstallationTokenScoped' AllRepositories permissions creds installationId
+-- 'generateInstallationTokenScoped' mempty {permissions} creds installationId
 -- @
 --
 -- Supplying the same permission more than once will take the higher:

--- a/src/GitHub/App/Token/Permissions.hs
+++ b/src/GitHub/App/Token/Permissions.hs
@@ -88,14 +88,14 @@ import Data.Map.Monoidal.Strict qualified as MonoidalMap
 newtype Permissions = Permissions
   { _unwrap :: MonoidalMap Text Permission
   }
-  deriving stock (Eq)
+  deriving stock (Eq, Show)
   deriving newtype (Semigroup, Monoid, ToJSON)
 
 data Permission
   = PermissionRead
   | PermissionWrite
   | PermissionAdmin
-  deriving stock (Eq)
+  deriving stock (Eq, Show)
 
 instance Semigroup Permission where
   _ <> PermissionAdmin = PermissionAdmin

--- a/tests/GitHub/App/Token/PermissionsSpec.hs
+++ b/tests/GitHub/App/Token/PermissionsSpec.hs
@@ -12,8 +12,7 @@ spec :: Spec
 spec = do
   describe "Semigroup" $ do
     it "resolves duplicates by taking higher permission" $ do
-      encode (checks Read <> checks Write)
-        `shouldBe` "{\"checks\":\"write\"}"
+      checks Read <> checks Write `shouldBe` checks Write
 
   describe "ToJSON" $ do
     it "encodes correctly" $ do

--- a/tests/GitHub/App/Token/PermissionsSpec.hs
+++ b/tests/GitHub/App/Token/PermissionsSpec.hs
@@ -1,0 +1,21 @@
+module GitHub.App.Token.PermissionsSpec
+  ( spec
+  ) where
+
+import GitHub.App.Token.Prelude
+
+import Data.Aeson
+import GitHub.App.Token.Permissions
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "Semigroup" $ do
+    it "resolves duplicates by taking higher permission" $ do
+      encode (checks Read <> checks Write)
+        `shouldBe` "{\"checks\":\"write\"}"
+
+  describe "ToJSON" $ do
+    it "encodes correctly" $ do
+      encode (checks Read <> actions Write)
+        `shouldBe` "{\"actions\":\"write\",\"checks\":\"read\"}"


### PR DESCRIPTION
Introduces a new function for specifying repositories or permissions for
the created token. This is accomplished by passing a value of type
`CreateAccessToken` which matches the `POST` body.

```hs
generateInstallationTokenScoped CreateAccessToken
  { repositories = ["foo/bar", ...]
  , repository_ids = [1, ...]
  , permissions = checks Read <> actions Write <> contents Read
  }
```

The type is a `Semigroup` and `Monoid` for better ergonomics of
construction and combination. The `Permissions` type is slightly
complicated, and will be annoying to maintain, but that's so it's
impossible to misuse.
