### PR TITLE
Fix docs repositories scope documentation

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -85,7 +85,7 @@ getScopedAppToken = do
   let
     creds = AppCredentials {appId, privateKey}
     create = mempty
-      { repositories = ["freckle/github-app-token"]
+      { repositories = ["github-app-token"]
       , permissions = contents Read
       }
 
@@ -135,6 +135,15 @@ main = do
     Hspec.describe "Basic usage" $ do
       Hspec.it "works" $ do
         token <- getAppToken
+        getRepo token "freckle/github-app-token"
+          `Hspec.shouldReturn` Repo
+            { name = "github-app-token"
+            , description = "Generate an installation token for a GitHub App"
+            }
+
+    Hspec.describe "Scoped usage" $ do
+      Hspec.it "works" $ do
+        token <- getScopedAppToken
         getRepo token "freckle/github-app-token"
           `Hspec.shouldReturn` Repo
             { name = "github-app-token"

--- a/src/GitHub/App/Token/Generate.hs
+++ b/src/GitHub/App/Token/Generate.hs
@@ -94,9 +94,11 @@ generateOwnerToken = generateOwnerTokenScoped mempty
 -- | <https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app>
 data CreateAccessToken = CreateAccessToken
   { repositories :: [Text]
-  -- ^ List of @{owner}/{name}@ values
+  -- ^ List of repository names that the token should have access to
   , repository_ids :: [Int]
+  -- ^ List of repository IDs that the token should have access to
   , permissions :: Permissions
+  -- ^ The permissions granted to the user access token
   }
   deriving stock (Eq, Generic)
   deriving anyclass (ToJSON)


### PR DESCRIPTION
The `repositories` element is names, not full `owner/name`s.
