### PR TITLE
Move markdown-unlit to build-tools

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -21,7 +21,6 @@ import Data.Traversable (for)
 import GitHub.App.Token.Refresh
 import System.Directory (doesFileExist)
 import Test.Hspec qualified as Hspec
-import Text.Markdown.Unlit ()
 ```
 -->
 

--- a/github-app-token.cabal
+++ b/github-app-token.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -90,6 +90,8 @@ test-suite readme
       RecordWildCards
       TypeFamilies
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe -pgmL markdown-unlit
+  build-tool-depends:
+      markdown-unlit:markdown-unlit
   build-depends:
       aeson
     , base <5
@@ -100,7 +102,6 @@ test-suite readme
     , hspec
     , http-conduit
     , http-types
-    , markdown-unlit
     , text
   default-language: GHC2021
   if impl(ghc >= 9.8)

--- a/package.yaml
+++ b/package.yaml
@@ -90,5 +90,6 @@ tests:
       - http-conduit
       - http-types
       - hspec
-      - markdown-unlit
       - text
+    build-tools:
+      - markdown-unlit


### PR DESCRIPTION
## Summary

This PR moves `markdown-unlit` from `dependencies` to `build-tools` in the package.yaml test configuration and removes the corresponding empty import from README.lhs.

## Why this change?

When `markdown-unlit` is listed in `dependencies`, we need to import it in the Haskell code to avoid unused-package warnings from GHC. However, since `markdown-unlit` is only used as a preprocessor (via `-pgmL markdown-unlit`), we don't actually need to import anything from it in our code.

By moving it to `build-tools` instead, we:
- Avoid unused-package warnings without needing empty imports
- Make the dependency relationship clearer (it's a build tool, not a runtime dependency)
- Follow Stack/Cabal best practices for preprocessor dependencies

## Changes

- Moved `markdown-unlit` from `dependencies` to `build-tools` in package.yaml
- Removed `import Text.Markdown.Unlit ()` from README.lhs
- Regenerated any files via `stack build --fast --test --no-run-tests`

🤖 Generated with Claude Code